### PR TITLE
fix permission problem, handle pipeline jobs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>1.601</version>
+        <version>1.607</version>
     </parent>
 
     <groupId>com.sonymobile.jenkins.plugins.lenientshutdown</groupId>
@@ -221,6 +221,12 @@
             <version>2.25</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-job</artifactId>
+            <version>1.15</version>
+            <scope>test</scope>
+        </dependency>        
     </dependencies>
 
     <distributionManagement>

--- a/src/main/java/com/sonymobile/jenkins/plugins/lenientshutdown/BuildPreventer.java
+++ b/src/main/java/com/sonymobile/jenkins/plugins/lenientshutdown/BuildPreventer.java
@@ -31,7 +31,7 @@ import com.sonymobile.jenkins.plugins.lenientshutdown.blockcauses.GlobalShutdown
 import com.sonymobile.jenkins.plugins.lenientshutdown.blockcauses.NodeShutdownBlockage;
 
 import hudson.Extension;
-import hudson.model.AbstractProject;
+import hudson.model.Job;
 import hudson.model.Node;
 import hudson.model.Queue;
 import hudson.model.queue.CauseOfBlockage;
@@ -56,6 +56,7 @@ public class BuildPreventer extends QueueTaskDispatcher {
     public CauseOfBlockage canRun(Queue.Item item) {
         CauseOfBlockage blockage = null; //Allow to run by default
 
+
         ShutdownManageLink shutdownManageLink = ShutdownManageLink.getInstance();
         boolean isGoingToShutdown = shutdownManageLink.isGoingToShutdown();
         ShutdownConfiguration configuration = ShutdownConfiguration.getInstance();
@@ -63,9 +64,9 @@ public class BuildPreventer extends QueueTaskDispatcher {
         boolean isWhiteListedUpStreamProject = false;
 
         if (isGoingToShutdown
-                && item.task instanceof AbstractProject
+                && item.task instanceof Job
                 && !shutdownManageLink.isPermittedQueueId(item.getId())) {
-            AbstractProject project = (AbstractProject)item.task;
+            Job project = (Job)item.task;
             isWhitelistedProject = shutdownManageLink.isActiveQueueIds()
                     && configuration.isWhiteListedProject(project.getFullName());
 
@@ -112,7 +113,7 @@ public class BuildPreventer extends QueueTaskDispatcher {
         boolean nodeIsGoingToShutdown = plugin.isNodeShuttingDown(nodeName);
 
         if (nodeIsGoingToShutdown
-                && item.task instanceof AbstractProject
+                && item.task instanceof Job
                 && !plugin.wasAlreadyQueued(item.getId(), nodeName)) {
 
             boolean otherNodeCanBuild = QueueUtils.canOtherNodeBuild(item, node);

--- a/src/main/java/com/sonymobile/jenkins/plugins/lenientshutdown/QueueUtils.java
+++ b/src/main/java/com/sonymobile/jenkins/plugins/lenientshutdown/QueueUtils.java
@@ -198,7 +198,7 @@ public final class QueueUtils {
                 Cause.UpstreamCause upstreamCause = (Cause.UpstreamCause)cause;
                 Run<?, ?> upstreamRun = upstreamCause.getUpstreamRun();
 
-                if (upstreamRun != null && upstreamRun instanceof Run) {
+                if (upstreamRun != null) {
                     upstreamBuilds.add(upstreamRun);
                 }
             }

--- a/src/main/java/com/sonymobile/jenkins/plugins/lenientshutdown/QueueUtils.java
+++ b/src/main/java/com/sonymobile/jenkins/plugins/lenientshutdown/QueueUtils.java
@@ -64,7 +64,9 @@ public final class QueueUtils {
     public static Set<Long> getPermittedQueueItemIds() {
         Set<Long> queuedIds = new HashSet<Long>();
         boolean allowAllQueuedItems = ShutdownConfiguration.getInstance().isAllowAllQueuedItems();
-        for (Queue.Item item : Queue.getInstance().getItems()) {
+        Queue.Item[] items = ShutdownManageLink.getInstance().getQueueItems();
+
+        for (Queue.Item item : items) {
             if (item.task instanceof AbstractProject) {
                 if (allowAllQueuedItems) {
                     queuedIds.add(item.getId());

--- a/src/main/java/com/sonymobile/jenkins/plugins/lenientshutdown/QueueUtils.java
+++ b/src/main/java/com/sonymobile/jenkins/plugins/lenientshutdown/QueueUtils.java
@@ -35,6 +35,7 @@ import hudson.model.AbstractBuild;
 import hudson.model.Cause;
 import hudson.model.Computer;
 import hudson.model.Executor;
+import hudson.model.Job;
 import hudson.model.Node;
 import hudson.model.Queue;
 import hudson.model.Run;
@@ -65,7 +66,7 @@ public final class QueueUtils {
         boolean allowAllQueuedItems = ShutdownConfiguration.getInstance().isAllowAllQueuedItems();
         Queue.Item[] items = ShutdownManageLink.getInstance().getQueueItems();
         for (Queue.Item item : items) {
-            if (item.task instanceof Run) {
+            if (item.task instanceof Job) {
                 if (allowAllQueuedItems) {
                     queuedIds.add(item.getId());
                 } else {
@@ -154,8 +155,8 @@ public final class QueueUtils {
 
                 for (Executor executor : executors) {
                     Queue.Executable executable = executor.getCurrentExecutable();
-                    if (executable instanceof AbstractBuild) {
-                        AbstractBuild build = (AbstractBuild)executable;
+                    if (executable instanceof Run) {
+                        Run build = (Run)executable;
                         runningProjects.add(build.getQueueId());
                     }
                 }


### PR DESCRIPTION
The runnable checking the Queue is not returning anything as it misses the context of the request and thus has not the permissions to read the Queue (unless anonymous is allowed read access).
So far the checks were based on AbstractBuild and AbstractProject. But the Workflow Job are based on Job and Run and were ignored, so they could still run.