### PR TITLE
make plugin pipeline friendly

### DIFF
--- a/src/main/java/com/sonymobile/jenkins/plugins/lenientshutdown/BuildPreventer.java
+++ b/src/main/java/com/sonymobile/jenkins/plugins/lenientshutdown/BuildPreventer.java
@@ -31,7 +31,7 @@ import com.sonymobile.jenkins.plugins.lenientshutdown.blockcauses.GlobalShutdown
 import com.sonymobile.jenkins.plugins.lenientshutdown.blockcauses.NodeShutdownBlockage;
 
 import hudson.Extension;
-import hudson.model.AbstractProject;
+import hudson.model.Job;
 import hudson.model.Node;
 import hudson.model.Queue;
 import hudson.model.queue.CauseOfBlockage;
@@ -63,9 +63,9 @@ public class BuildPreventer extends QueueTaskDispatcher {
         boolean isWhiteListedUpStreamProject = false;
 
         if (isGoingToShutdown
-                && item.task instanceof AbstractProject
+                && item.task instanceof Job
                 && !shutdownManageLink.isPermittedQueueId(item.getId())) {
-            AbstractProject project = (AbstractProject)item.task;
+            Job project = (Job)item.task;
             isWhitelistedProject = shutdownManageLink.isActiveQueueIds()
                     && configuration.isWhiteListedProject(project.getFullName());
 
@@ -112,7 +112,7 @@ public class BuildPreventer extends QueueTaskDispatcher {
         boolean nodeIsGoingToShutdown = plugin.isNodeShuttingDown(nodeName);
 
         if (nodeIsGoingToShutdown
-                && item.task instanceof AbstractProject
+                && item.task instanceof Job
                 && !plugin.wasAlreadyQueued(item.getId(), nodeName)) {
 
             boolean otherNodeCanBuild = QueueUtils.canOtherNodeBuild(item, node);

--- a/src/main/java/com/sonymobile/jenkins/plugins/lenientshutdown/QueueUtils.java
+++ b/src/main/java/com/sonymobile/jenkins/plugins/lenientshutdown/QueueUtils.java
@@ -32,10 +32,10 @@ import java.util.List;
 import java.util.Set;
 
 import hudson.model.AbstractBuild;
-import hudson.model.AbstractProject;
 import hudson.model.Cause;
 import hudson.model.Computer;
 import hudson.model.Executor;
+import hudson.model.Job;
 import hudson.model.Node;
 import hudson.model.Queue;
 import hudson.model.Run;
@@ -65,7 +65,7 @@ public final class QueueUtils {
         Set<Long> queuedIds = new HashSet<Long>();
         boolean allowAllQueuedItems = ShutdownConfiguration.getInstance().isAllowAllQueuedItems();
         for (Queue.Item item : Queue.getInstance().getItems()) {
-            if (item.task instanceof AbstractProject) {
+            if (item.task instanceof Job) {
                 if (allowAllQueuedItems) {
                     queuedIds.add(item.getId());
                 } else {


### PR DESCRIPTION
Use Job instead of AbstractProject to watch on WorkflowJob queue items.
After this change plugin will block new pipeline jobs as well and allow
already running to continue.

Signed-off-by: Artur Harasimiuk <artur.harasimiuk@intel.com>