### PR TITLE
tools: upgrade JDK to 11 in Jenkinsfile only

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 buildPlugin(
   useContainerAgent: true,
   configurations: [
-    [platform: 'linux', jdk: 8],
-    [platform: 'windows', jdk: 8],
+    [platform: 'linux', jdk: 11],
+    [platform: 'windows', jdk: 11],
 ])


### PR DESCRIPTION
#14 is failing to build because it's using the `Jenkinsfile` from the target branch as a security precaution.  This pull request therefore breaks out the upgrade to the `Jenkinsfile` such that we can merge it _first_, and then builds of #14 should be able to proceed.

### Testing done

None, this is just a theory and we'll know it's working when:
1. The builds for this PR complete successfully in Jenkins.
2. The builds for subsequent PRs that make use of JDK11 (such as #14) will also complete successfully in Jenkins.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
