### PR TITLE
tools: upgrade Jenkinsfile JDK to 21

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,7 @@
 buildPlugin(
   useContainerAgent: true,
   configurations: [
+    [platform: 'linux', jdk: 17],
     [platform: 'linux', jdk: 21],
     [platform: 'windows', jdk: 21],
 ])


### PR DESCRIPTION
My next pull request will upgrade the rest to JDK 21, but this must be merged first, because the `Jenkinsfile` is obtained from the pull request's target branch for security reasons.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
