### PR TITLE
Migrate from Commons Lang to native Java Platform functionality

### DIFF
--- a/src/main/java/com/sonymobile/jenkins/plugins/lenientshutdown/ShutdownConfiguration.java
+++ b/src/main/java/com/sonymobile/jenkins/plugins/lenientshutdown/ShutdownConfiguration.java
@@ -30,7 +30,6 @@ import java.util.Set;
 import java.util.TreeSet;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.StaplerRequest2;
 
 import hudson.Extension;
@@ -153,7 +152,7 @@ public class ShutdownConfiguration extends GlobalConfiguration {
      * @return string with the white listed projects separated by newlines
      */
     public String getWhiteListedProjectsText() {
-        return StringUtils.join(whiteListedProjects, "\n");
+        return String.join("\n", whiteListedProjects);
     }
 
     /**


### PR DESCRIPTION
No need to depend on a third-party library here when the Java Platform provides this functionality natively.

Part of the effort to remove Commons Lang 2 from Jenkins core — jenkinsci/jenkins#16404,
jenkinsci/jenkins#26105. Commons Lang 2 is EOL and carries an unfixed advisory
(GHSA-j288-q9x7-2f5v).

`StringUtils.join(whiteListedProjects, "\n")` → `String.join("\n", whiteListedProjects)`.
`whiteListedProjects` is a `Set<String>` initialised at declaration and never reassigned to null, so the
null-handling difference between the two does not arise.

### Testing done

`mvn -B -ntp clean verify` on Java 21 / macOS: 57 tests, 12 failures — and unmodified `master`
gives exactly the same 57 tests and 12 failures, so they are pre-existing and unrelated to this
change. They are all CLI command tests (`ToggleLenientQuietDownCommandTest`,
`CancelLenientQuietDownCommandTest`, `LenientOfflineNodeCommandTest`) exiting 255 where the test
expects 0. Everything else passes.
The `ban-commons-lang-2` enforcer rule was left disabled because it needs parent POM
`6.2116.v7501b_67dc517` or newer; bumping the parent from `5.26` was out of scope here.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

---

🤖 This pull request was generated with AI assistance (Claude Code) as part of a bulk migration
across Jenkins plugins. If anything here looks wrong, please comment on this PR or contact
@parameter.
